### PR TITLE
Add missing Steps instructions

### DIFF
--- a/steps/STEP_2.md
+++ b/steps/STEP_2.md
@@ -44,7 +44,7 @@ Here we will use the wireframe planning and layout to identify the components an
 </div>
 ```
 
-Giving the sidenav a default width of `320px`
+Giving the host element a flex property of `1` to fill height and sidenav a default width of `320px`
 
 ###### File:  `src/app/app.component.css`
 

--- a/steps/STEP_2.md
+++ b/steps/STEP_2.md
@@ -49,6 +49,11 @@ Giving the sidenav a default width of `320px`
 ###### File:  `src/app/app.component.css`
 
 ```css
+:host {
+  display: flex;
+  flex: 1;
+}
+
 md-sidenav {
   width: 320px;
 }

--- a/steps/STEP_4.md
+++ b/steps/STEP_4.md
@@ -49,6 +49,7 @@ By that, we can have `<md-icon svgIcon="[namespace]:[id]">` and it would look th
 ```ts
 import {Component} from '@angular/core';
 import {MdIconRegistry} from '@angular/material';
+import {DomSanitizer} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',


### PR DESCRIPTION
Add missing styles to STEP_2,md for sidenav to display.

Following the instructions step-by-step, the end of step 2 didn't have the user put in :host{} pseudo-element styling needed to display sidenav. 